### PR TITLE
Update Cargo.toml remove www

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/money2"
 keywords = ["currency", "exchange", "finance", "iso-4217", "money"]
 license = "GPL-3.0-only"
 readme = "README.md"
-repository = "https://www.github.com/Iron-E/money"
+repository = "https://github.com/Iron-E/money"
 
 [dependencies]
 chrono = "0.4"


### PR DESCRIPTION
github redirects anyway, so better leave it out